### PR TITLE
Try MathJax - if don't use raw for equations

### DIFF
--- a/_posts/2017-11-01-OPN-summary.md
+++ b/_posts/2017-11-01-OPN-summary.md
@@ -14,9 +14,10 @@ icon: icon-apache
 
 ## Heat Is the New Light
 
-{% raw %}
-  $$a^2 + b^2 = c^2$$ --> note that all equations between these tags will not need escaping! 
- {% endraw %}
+
+  $$a^2 + b^2 = c^2$$ 
+
+ 
 
 
   


### PR DESCRIPTION
If don't use {% raw %} {% endraw %} pairs, does it work?
If so, then MathJax and markdown+math in vscode can be used simultaneously